### PR TITLE
Reference without duplication (rsv-A)

### DIFF
--- a/ingest/workflow/snakemake_rules/sort.smk
+++ b/ingest/workflow/snakemake_rules/sort.smk
@@ -1,6 +1,6 @@
 """
 This part of the workflow handles sorting downloaded sequences and metadata
-into a and b by aligning them to reference sequences. 
+into a and b by aligning them to reference sequences.
 
 It produces output files as
 
@@ -13,14 +13,15 @@ It produces output files as
 TIME = ['1', '2','3']
 
 rule align:
-    input: 
+    input:
         sequences = rules.transform.output.sequences,
         reference = "config/{type}_{time}_reference.fasta"
     output:
         alignment = "data/{type}/{time}_sequences.aligned.fasta"
+    threads: 2
     shell:
         """
-        nextalign run \
+        nextalign run -j {threads}\
         --reference {input.reference} \
         --output-fasta {output.alignment} \
         {input.sequences}
@@ -62,7 +63,7 @@ rule sort:
         metadata_b = "data/b/metadata_notdedup.tsv"
     shell:
         """
-        python bin/sort.py 
+        python bin/sort.py
         """
 
 rule deduplication:
@@ -70,7 +71,7 @@ rule deduplication:
         sequences_a = rules.sort.output.sequences_a,
         metadata_a = rules.sort.output.metadata_a,
         sequences_b = rules.sort.output.sequences_b,
-        metadata_b = rules.sort.output.metadata_b     
+        metadata_b = rules.sort.output.metadata_b
     output:
         dedup_seq_a = "data/a/sequences.fasta",
         dedup_metadata_a = "data/a/metadata.tsv",

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -115,9 +115,10 @@ rule realign:
         reference = rules.newreference.output.greference
     output:
         realigned = build_dir + "/{a_or_b}/{build_name}/realigned.fasta"
+    threads: 4
     shell:
         """
-        augur align \
+        augur align --nthreads {threads} \
             --sequences {input.newalignment} \
             --reference-sequence {input.reference} \
             --output {output.realigned}
@@ -148,12 +149,13 @@ rule tree:
         alignment = rules.alignment_for_tree.output
     output:
         tree = build_dir + "/{a_or_b}/{build_name}/tree_raw.nwk"
+    threads: 4
     shell:
         """
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
-            --nthreads 4
+            --nthreads {threads}
         """
 
 rule refine:

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -86,16 +86,17 @@ rule align:
         reference = "config/{a_or_b}reference.fasta"
     output:
         alignment = build_dir + "/{a_or_b}/{build_name}/sequences.aligned.fasta"
+    threads: 4
     shell:
         """
-        nextalign run \
+        nextalign run -j {threads}\
             --reference {input.reference} \
             --output-fasta {output.alignment} \
             {input.sequences}
         """
 
 rule cut:
-    input: 
+    input:
         oldalignment = rules.align.output.alignment,
         reference = "config/{a_or_b}reference.gbk"
     output:
@@ -109,7 +110,7 @@ rule cut:
         """
 
 rule realign:
-    input: 
+    input:
         newalignment = rules.cut.output.newalignment,
         reference = rules.newreference.output.greference
     output:
@@ -119,7 +120,7 @@ rule realign:
         augur align \
             --sequences {input.newalignment} \
             --reference-sequence {input.reference} \
-            --output {output.realigned} 
+            --output {output.realigned}
         """
 
 rule alignment_for_tree:

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -168,7 +168,7 @@ rule refine:
         """
     input:
         tree = rules.tree.output.tree,
-        alignment = rules.align.output.alignment,
+        alignment = rules.alignment_for_tree.output,
         metadata = rules.filter.input.metadata
     output:
         tree = build_dir + "/{a_or_b}/{build_name}/tree.nwk",
@@ -189,6 +189,7 @@ rule refine:
             --date-inference {params.date_inference} \
             --date-confidence \
             --timetree \
+            --use-fft \
             --clock-filter-iqd {params.clock_filter_iqd}
         """
 


### PR DESCRIPTION
### Description of proposed changes

This version of the workflow uses a reference without duplication in the G gene for RSV-A.

