### PR TITLE
Fix strain name matching

### DIFF
--- a/config/configfile.yaml
+++ b/config/configfile.yaml
@@ -17,7 +17,7 @@ filter:
     genome: 10000
     G: 600
     F: 600
-  subsample_max_sequences: 200
+  subsample_max_sequences: 2000
 
 files:
   color_schemes: "config/colors.tsv"

--- a/config/configfile.yaml
+++ b/config/configfile.yaml
@@ -6,6 +6,9 @@ buildstorun: ["genome", "G"]
 
 description: "config/description.md"
 
+strain_id_field: "accession"
+display_strain_field: "strain_original"
+
 subtypes: ['a', 'b']
 
 filter:
@@ -14,7 +17,7 @@ filter:
     genome: 10000
     G: 600
     F: 600
-  subsample_max_sequences: 1000
+  subsample_max_sequences: 200
 
 files:
   color_schemes: "config/colors.tsv"

--- a/scripts/set_final_strain_name.py
+++ b/scripts/set_final_strain_name.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import json, argparse
+
+def replace_name_recursive(node, lookup):
+    if node["name"] in lookup:
+        node["name"] = lookup[node["name"]]
+
+    if "children" in node:
+        for child in node["children"]:
+            replace_name_recursive(child, lookup)
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="remove time info",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--input-auspice-json', type=str, required=True, help="input auspice_json")
+    parser.add_argument('--metadata', type=str, required=True, help="input data")
+    parser.add_argument('--display-strain-name', type=str, required=True, help="field to use as strain name in auspice")
+    parser.add_argument('--output', type=str, metavar="JSON", required=True, help="output Auspice JSON")
+    args = parser.parse_args()
+
+    metadata = pd.read_csv(args.metadata, sep='\t')
+    name_lookup = {}
+    for ri, row in metadata.iterrows():
+        strain_id = row['strain']
+        name_lookup[strain_id] = args.display_strain_name if pd.isna(row[args.display_strain_name]) else row[args.display_strain_name]
+
+    with open(args.input_auspice_json, 'r') as fh:
+        data = json.load(fh)
+
+    replace_name_recursive(data['tree'], name_lookup)
+
+    with open(args.output, 'w') as fh:
+        json.dump(data, fh)

--- a/scripts/wrangle_metadata.py
+++ b/scripts/wrangle_metadata.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import argparse
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="remove time info",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--metadata', type=str, required=True, help="input data")
+    parser.add_argument('--strain-id', type=str, required=True, help="field to use as strain id")
+    parser.add_argument('--output', type=str, required=True, help="output metadata")
+    args = parser.parse_args()
+
+    metadata = pd.read_csv(args.metadata, sep='\t')
+    if 'strain' in metadata.columns:
+        metadata.rename(columns={'strain': 'strain_original'}, inplace=True)
+
+    # copy column, retaining original
+    # ie keep "accession" but also include "strain" with data from previous "accession" column
+    # insert this as the first column in the dataframe
+    metadata.insert(0, "strain", metadata[args.strain_id])
+    # metadata["strain"] = metadata[args.strain_id]
+
+    metadata.to_csv(args.output, sep='\t', index=False)

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -4,6 +4,19 @@ This part of the workflow expects input files
             metadata = "data/metadata.tsv"
 '''
 
+rule wrangle_metadata:
+    input:
+        metadata="data/{a_or_b}/metadata.tsv",
+    output:
+        metadata="data/{a_or_b}/metadata_by_accession.tsv",
+    params:
+        strain_id=lambda w: config.get("strain_id_field", "strain"),
+    shell:
+        """
+        python3 scripts/wrangle_metadata.py --metadata {input.metadata} \
+                    --strain-id {params.strain_id} \
+                    --output {output.metadata}
+        """
 
 rule index_sequences:
     message:
@@ -50,13 +63,12 @@ rule newreference:
 rule filter:
     message:
         """
-        Aligning sequences to {input.reference}
-            - gaps relative to reference are considered real
+        filtering sequences
         """
     input:
         sequences = "data/{a_or_b}/sequences.fasta",
         reference = "config/{a_or_b}reference.gbk",
-        metadata = "data/{a_or_b}/metadata.tsv",
+        metadata = "data/{a_or_b}/metadata_by_accession.tsv",
         sequence_index = rules.index_sequences.output
     output:
     	sequences = build_dir + "/{a_or_b}/{build_name}/filtered.fasta"


### PR DESCRIPTION
Our builds so far included strains only when the strain name matched the accession number. This should now be fixed. 