### PR TITLE
Update PAT_GITHUB_DISPATCH secret

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -61,7 +61,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        PAT_GITHUB_DISPATCH: ${{ secrets.PAT_GITHUB_DISPATCH }}
+        PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
 
     - name: notify_pipeline_failed
       if: ${{ failure() }}


### PR DESCRIPTION
Use the shared organization secret for the dispatch token so it no longer has to be managed as a separate repo secret.

I've already added the org secret `GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH` to this repo.