### PR TITLE
Store record count in S3 metadata

### DIFF
--- a/ingest/bin/notify-on-record-change
+++ b/ingest/bin/notify-on-record-change
@@ -14,8 +14,20 @@ source_name=${3:?A record source name is required as the third argument.}
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
+s3path="${dst#s3://}"
+bucket="${s3path%%/*}"
+key="${s3path#*/}"
+
 src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+
+# Try getting record count from S3 object metadata
+dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query "Metadata.recordcount || ''" --output text 2>/dev/null || true)"
+if [[ -z "$dst_record_count" ]]; then
+  # This object doesn't have the record count stored as metadata
+  # We have to download it and count the lines locally
+  dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+fi
+
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/ingest/bin/upload-to-s3
+++ b/ingest/bin/upload-to-s3
@@ -30,6 +30,9 @@ main() {
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     if [[ $src_hash != "$dst_hash" ]]; then
+        # The record count may have changed
+        src_record_count="$(wc -l < "$src")"
+
         echo "Uploading $src → $dst"
         if [[ "$dst" == *.gz ]]; then
             gzip -c "$src"
@@ -37,7 +40,7 @@ main() {
             xz -2 -T0 -c "$src"
         else
             cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
 
         if [[ -n $cloudfront_domain ]]; then
             echo "Creating CloudFront invalidation for $cloudfront_domain/$key"


### PR DESCRIPTION
### Description of proposed changes

This applies changes taken from https://github.com/nextstrain/ncov-ingest/pull/316. In summary, we can store the number of records as metadata of the S3 object (like we do for the SHA-256 hash) instead of having to download the file, uncompress it, and count the number of records. This is also in [nextstrain/monkeypox](https://github.com/nextstrain/monkeypox/blob/644d07ebe3fa5ded64d27d0964064fb722797c5d/ingest/bin/notify-on-record-change#L23)

### Related issue(s)

None

### Testing

- [x] Checks pass