### PR TITLE
fix: Add `--cores` to gh actions nextstrain build

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -56,6 +56,7 @@ jobs:
           ingest \
             envdir env.d snakemake \
               --configfiles config/config.yaml config/optional.yaml \
+              --cores 8 \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -55,6 +55,7 @@ jobs:
           . \
             envdir env.d snakemake notify_on_deploy \
               --configfiles config/configfile.yaml config/nextstrain_automation.yaml \
+              --cores 16 \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
This is required for the action to be compatible with snakemake version >5.11.0
which started to require the `--cores` option

For more context see:
- https://github.com/nextstrain/cli/issues/272 
- https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1681324279363569?thread_ts=1681293140.124269&cid=C01LCTT7JNN