### PR TITLE
remove conda statement from fetch_from_genbank (the only rule that ha…

### DIFF
--- a/ingest/workflow/snakemake_rules/fetch_sequences.smk
+++ b/ingest/workflow/snakemake_rules/fetch_sequences.smk
@@ -20,7 +20,6 @@ rule fetch_from_genbank:
         URL_a = config['fetch']['genbank_url']['a'],
         URL_b = config['fetch']['genbank_url']['b'],
         URL_general = config['fetch']['genbank_url']['general']
-    conda: config["conda_environment"]
     shell:
         """
         curl "{params.URL_a}" --fail --silent --show-error --http1.1 \


### PR DESCRIPTION
…d it)

`ingest` previously errored when run via github actions with 
```
[batch] WorkflowError:                                                         
[batch] Failed to open source file /nextstrain/build/workflow/snakemake_rules/workflow/envs/nextstrain.yaml
[batch] FileNotFoundError: [Errno 2] No such file or directory: '/nextstrain/build/workflow/snakemake_rules/workflow/envs/nextstrain.yaml'
[batch] Removing output files of failed job fetch_from_genbank since they might be corrupted:
[batch] data/genbank.csv
```

The `fetch_from_genbank` rule was the only one with an explicit `conda` directive. I assume `conda` isn't used here at all. The `nextstrain.yml` file is there, so I don't really understand the root cause of the error.  
