### PR TITLE
fix: Treat geolocation-rules.tsv and annotations.tsv as input files

### DIFF
--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -45,9 +45,9 @@ transform:
   geolocation_rules_url: 'https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv'
   # Local geolocation rules that are only applicable to rsv data
   # Local rules can overwrite the general geolocation rules provided above
-  local_geolocation_rules: './source-data/geolocation-rules.tsv'
+  local_geolocation_rules: 'source-data/geolocation-rules.tsv'
   # User annotations file
-  annotations: './source-data/annotations.tsv'
+  annotations: 'source-data/annotations.tsv'
   # ID field used to merge annotations
   annotations_id: 'accession'
   # Field to use as the sequence ID in the FASTA file

--- a/ingest/workflow/snakemake_rules/transform.smk
+++ b/ingest/workflow/snakemake_rules/transform.smk
@@ -39,7 +39,8 @@ rule concat_geolocation_rules:
 rule transform:
     input:
         sequences_ndjson = "data/sequences.ndjson",
-        all_geolocation_rules = "data/all-geolocation-rules.tsv"
+        all_geolocation_rules = "data/all-geolocation-rules.tsv",
+        annotations = config['transform']['annotations'],
     output:
         metadata = "data/metadata.tsv",
         sequences = "data/sequences.fasta"
@@ -57,7 +58,6 @@ rule transform:
         authors_field = config['transform']['authors_field'],
         authors_default_value = config['transform']['authors_default_value'],
         abbr_authors_field = config['transform']['abbr_authors_field'],
-        annotations = config['transform']['annotations'],
         annotations_id = config['transform']['annotations_id'],
         metadata_columns = config['transform']['metadata_columns'],
         id_field = config['transform']['id_field'],
@@ -86,7 +86,7 @@ rule transform:
             | ./bin/apply-geolocation-rules \
                 --geolocation-rules {input.all_geolocation_rules} \
             | ./bin/merge-user-metadata \
-                --annotations {params.annotations} \
+                --annotations {input.annotations} \
                 --id-field {params.annotations_id} \
             | ./bin/ndjson-to-tsv-and-fasta \
                 --fasta {output.sequences} \


### PR DESCRIPTION
### Description of proposed changes

This commit modifies the configurations and snakemake rules to treat geolocation-rules.tsv and annotations.tsv as input files instead of strings. This change addresses a warning message that occurs when using relative file paths starting with './'. The warning suggests omitting the './' to avoid redundancy and ensure consistent file matching in Snakemake.

```
Relative file path './source-data/geolocation-rules.tsv' starts with './'. This is redundant and strongly discouraged. It can also lead to inconsistent results of the file-matching approach used by Snakemake. You can simply omit the './' for relative file paths.
```

Furthermore, by treating source-data/annotations.tsv as a file, it provides hints to snakemake modules to add a prefix, such as "ingest/source-data/", if necessary. This modification aligns with the changes made in the following pull request: https://github.com/nextstrain/dengue/pull/10

### Related issue(s)

* https://github.com/nextstrain/monkeypox/pull/157
* https://github.com/nextstrain/dengue/pull/10

### Testing

- [ ] Checks pass

Ran a manual check with:

```
git clone https://github.com/nextstrain/rsv.git original
git clone https://github.com/nextstrain/rsv.git changed

cd original/ingest
nextstrain build .  data/metadata.tsv

cd ../../changed/ingest
nextstrain build . data/metadata.tsv

diff data/metadata.tsv ../../original/ingest/metadata.tsv         # No changes
```

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
