### PR TITLE
Remove deduplication on `strain`

### DIFF
--- a/ingest/bin/gene-coverage.py
+++ b/ingest/bin/gene-coverage.py
@@ -53,7 +53,7 @@ if __name__=="__main__":
             F_coverage[accession].append(coverages_F.get(accession, 0.00))
             genome_coverage[accession].append(coverage_genome.get(accession, 0.00))
 
-    metadata_files = ["data/b/metadata_no_covg.tsv", "data/a/metadata_no_covg.tsv"]
+    metadata_files = ["data/b/metadata_sorted.tsv", "data/a/metadata_sorted.tsv"]
     outputs = ["data/b/metadata.tsv", "data/a/metadata.tsv"]
 
     # this part of the script reads the already separated a and b metadata and adds the F and G covg values to the correct row based on accession

--- a/ingest/bin/sort.py
+++ b/ingest/bin/sort.py
@@ -59,8 +59,8 @@ if __name__=="__main__":
             elif a_or_b[record.id]=='B':
                 b_sequences.append(record)
 
-    SeqIO.write(a_sequences, "data/a/sequences_notdedup.fasta","fasta")
-    SeqIO.write(b_sequences, "data/b/sequences_notdedup.fasta", "fasta")
+    SeqIO.write(a_sequences, "data/a/sequences.fasta","fasta")
+    SeqIO.write(b_sequences, "data/b/sequences.fasta", "fasta")
 
     metadata = pd.read_csv("data/metadata.tsv", sep="\t", index_col='accession')
     original_columns = metadata.columns
@@ -71,5 +71,5 @@ if __name__=="__main__":
                               columns=original_columns)
     b_metadata = pd.DataFrame(data=metadata.loc[metadata['type']=='B'],
                               columns=original_columns)
-    a_metadata.to_csv('data/a/metadata_notdedup.tsv', sep="\t")
-    b_metadata.to_csv('data/b/metadata_notdedup.tsv', sep="\t")
+    a_metadata.to_csv('data/a/metadata_sorted.tsv', sep="\t")
+    b_metadata.to_csv('data/b/metadata_sorted.tsv', sep="\t")

--- a/ingest/workflow/snakemake_rules/sort.smk
+++ b/ingest/workflow/snakemake_rules/sort.smk
@@ -57,9 +57,9 @@ rule sort:
         metadata_b = expand("data/b/{time}_metadata.tsv", time=TIME),
         metadata_a = expand("data/a/{time}_metadata.tsv", time=TIME)
     output:
-        sequences_a = "data/a/sequences_notdedup.fasta",
+        sequences_a = "data/a/sequences.fasta",
         metadata_a = "data/a/metadata_notdedup.tsv",
-        sequences_b = "data/b/sequences_notdedup.fasta",
+        sequences_b = "data/b/sequences.fasta",
         metadata_b = "data/b/metadata_notdedup.tsv"
     shell:
         """
@@ -68,20 +68,13 @@ rule sort:
 
 rule deduplication:
     input:
-        sequences_a = rules.sort.output.sequences_a,
         metadata_a = rules.sort.output.metadata_a,
-        sequences_b = rules.sort.output.sequences_b,
         metadata_b = rules.sort.output.metadata_b
     output:
-        dedup_seq_a = "data/a/sequences.fasta",
         dedup_metadata_a = "data/a/metadata_no_covg.tsv",
-        dedup_seq_b = "data/b/sequences.fasta",
         dedup_metadata_b = "data/b/metadata_no_covg.tsv"
     shell:
         """
-        seqkit rmdup < {input.sequences_a} > {output.dedup_seq_a}
-        seqkit rmdup < {input.sequences_b} > {output.dedup_seq_b}
-
         python bin/metadata_dedup.py \
             --metadata-original {input.metadata_a} \
             --metadata-output {output.dedup_metadata_a}

--- a/ingest/workflow/snakemake_rules/sort.smk
+++ b/ingest/workflow/snakemake_rules/sort.smk
@@ -58,30 +58,12 @@ rule sort:
         metadata_a = expand("data/a/{time}_metadata.tsv", time=TIME)
     output:
         sequences_a = "data/a/sequences.fasta",
-        metadata_a = "data/a/metadata_notdedup.tsv",
+        metadata_a = "data/a/metadata_sorted.tsv",
         sequences_b = "data/b/sequences.fasta",
-        metadata_b = "data/b/metadata_notdedup.tsv"
+        metadata_b = "data/b/metadata_sorted.tsv"
     shell:
         """
         python bin/sort.py
-        """
-
-rule deduplication:
-    input:
-        metadata_a = rules.sort.output.metadata_a,
-        metadata_b = rules.sort.output.metadata_b
-    output:
-        dedup_metadata_a = "data/a/metadata_no_covg.tsv",
-        dedup_metadata_b = "data/b/metadata_no_covg.tsv"
-    shell:
-        """
-        python bin/metadata_dedup.py \
-            --metadata-original {input.metadata_a} \
-            --metadata-output {output.dedup_metadata_a}
-
-        python bin/metadata_dedup.py \
-            --metadata-original {input.metadata_b} \
-            --metadata-output {output.dedup_metadata_b}
         """
 
 rule coverage:
@@ -90,8 +72,8 @@ rule coverage:
         alignment_b = expand("data/b/{time}_sequences.aligned.fasta", time=TIME),
         metadata_b = expand("data/b/{time}_metadata.tsv", time=TIME),
         metadata_a = expand("data/a/{time}_metadata.tsv", time=TIME),
-        dedup_metadata_a = rules.deduplication.output.dedup_metadata_a,
-        dedup_metadata_b = rules.deduplication.output.dedup_metadata_b
+        sorted_metadata_a = "data/a/metadata_sorted.tsv",
+        sorted_metadata_b = "data/b/metadata_sorted.tsv"
     output:
         metadata_a = "data/a/metadata.tsv",
         metadata_b = "data/b/metadata.tsv"


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

On the phylogenetic workflow side, the metadata is processed with accession as the ID column, which should be unique. De-duplicating on strain (which is what was previously done) would only result in a loss of data.

Furthermore, sequences are already written by accession so there is no need for deduplication there.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Prompted by [Slack discussion](https://bedfordlab.slack.com/archives/C03BBQ62RSL/p1691603054347129).

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass, though they don't test the changes here
- [x] [Partial](https://github.com/nextstrain/rsv/commit/0aa8600e62fef86b5e639009cd6c18b2798a38c4) ingest workflow runs locally without errors

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
