### PR TITLE
config/clades: remove excess whitespace

### DIFF
--- a/config/clades_G_a.tsv
+++ b/config/clades_G_a.tsv
@@ -3,80 +3,80 @@ GA1	G	141	A
 GA1	G	121	G
 GA1	G	244	I
 GA1	G	296	P
-			
+
 GA2	G	111	P
-			
+
 GA2.1	G	229	N
-			
+
 GA2.2	G	122	A
 GA2.2	G	114	T
 GA2.2	G	115	P
-			
+
 GA2.3	G	122	A
 GA2.3	G	156	Q
 GA2.3	G	289	S
 GA2.3	G	269	T
-			
+
 GA2.3.1	clade	GA2.3	
 GA2.3.1	G	254	E
 GA2.3.1	G	252	I
-			
+
 GA2.3.2	clade	GA2.3	
 GA2.3.2	G	133	I
-			
+
 GA2.3.2a	clade	GA2.3.2	
 GA2.3.2a	G	242	S
 GA2.3.2a	G	225	I
-			
+
 GA2.3.2b	clade	GA2.3.2	
 GA2.3.2b	G	112	I
 GA2.3.2b	G	141	M
 GA2.3.2b	G	244	K
-			
+
 GA2.3.3	clade	GA2.3	
 GA2.3.3	G	111	S
 GA2.3.3	G	292	S
-			
+
 GA2.3.4	clade	GA2.3	
 GA2.3.4	G	273	Y
 GA2.3.4	G	210	L
-			
+
 GA2.3.5	clade	GA2.3	
 GA2.3.5	G	232	G
 GA2.3.5	G	253	K
-			
+
 GA3	G	111	T
 GA3	G	250	N
-			
+
 GA3.0.0	G	111	T
 GA3.0.0	G	250	N
-			
+
 GA3.0.1	G	102	F
 GA3.0.1	G	193	S
 GA3.0.1	G	295	I
-			
+
 GA3.0.2	clade	GA3	
 GA3.0.2	G	113	A
 GA3.0.2	G	125	I
 GA3.0.2	G	274	T
-			
+
 GA3.0.3	clade	GA3	
 GA3.0.3	G	161	D
 GA3.0.3	G	297	D
-			
+
 GA3.0.3a	clade	GA3.0.3	
 GA3.0.3a	G	232	D
-			
+
 GA3.0.4a	clade	GA3.0.3a	
 GA3.0.4a	G	227	S
-			
+
 GA3.0.3b	clade	GA3.0.3	
-			
+
 GA3.0.4b	clade	GA3.0.3b	
 GA3.0.4b 	G	219	P
 GA3.0.4b 	G	224	P
 GA3.0.4b 	G	208	Q
 GA3.0.4b 	G	246	L
-			
+
 GA3.0.5b	clade	GA3.0.4b	
 GA3.0.5b	G	153	K

--- a/config/clades_G_b.tsv
+++ b/config/clades_G_b.tsv
@@ -3,50 +3,50 @@ GB1	G	150	S
 GB1	G	280	I
 GB1	G	208	I
 GB1	G	222	M
-			
+
 GB2	G	118	T
 GB2	G	223	T
 GB2	G	257	L
-			
+
 GB3	G	136	I
 GB3	G	71	P
 GB3	G	109	L
-			
+
 GB4	G	222	A
 GB4	G	219	S
 GB4	G	258	D
-			
+
 GB5	G	143	N
 GB5	G	237	P
-			
+
 GB5.0.0	G	143	N
 GB5.0.0	G	237	P
-			
+
 GB5.0.1	clade	GB5	
 GB5.0.1	G	247	P
-			
+
 GB5.0.2	clade	GB5.0.1	
 GB5.0.2	G	223	P
 GB5.0.2	G	138	S
-			
+
 GB5.0.3	clade	GB5.0.2	
 GB5.0.3	G	269	A
-			
+
 GB5.0.4a	G	282	T
 GB5.0.4a	G	200	T
-			
+
 GB5.0.5a	clade	GB5.0.0	
 GB5.0.5a	G	136	T
-			
+
 GB5.0.4b	G	153	R
 GB5.0.4b	G	266	L
-			
+
 GB5.0.4c	clade	GB5.0.3	
 GB5.0.4c	G	285	D
-			
+
 GB7	G	242	K
 GB7	G	214	I
-			
+
 GB6	G	235	L
 GB6	G	126	K
 GB6	G	262	P

--- a/config/clades_genome_a.tsv
+++ b/config/clades_genome_a.tsv
@@ -5,91 +5,91 @@ A1	nuc	479	T
 A1	nuc	861	G
 A1	F	16	I
 A1	L	81	L
-			
+
 A2	clade	A1	
 A2	G	110	L
 A2	G	197	R
 A2	L	2016	I
-			
+
 A3	nuc	3026	A
 A3	nuc	4019	A
 A3	nuc	4416	A
-			
+
 A4	nuc	7516	G
 A4	nuc	13658	G
-			
+
 A5	nuc	4905	G
 A5	nuc	5588	G
 A5	nuc	7501	C
 A5	nuc	8577	C
 A5	nuc	11541	C
-			
+
 A6	nuc	134	C
 A6	nuc	1281	G
-			
+
 A7	nuc	3070	G
 A7	nuc	3998	T
 A7	nuc	4013	C
 A7	nuc	3536	C
-			
+
 A8	nuc	603	T
 A8	nuc	1949	A
 A8	nuc	2516	C
 A8	nuc	3155	T
-			
+
 A9	clade	A8	
 A9	nuc	3188	G
 A9	nuc	5113	G
 A9	nuc	4220	C
-			
+
 A10	clade	A9	
 A10	nuc	2541	A
 A10	nuc	3188	A
 A10	G	117	S
 A10	nuc	4982	C
-			
-			
+
+
 A11	nuc	5642	G
 A11	nuc	7369	T
 A11	nuc	9213	T
-			
-			
+
+
 A12	nuc	2934	C
 A12	nuc	7919	A
 A12	nuc	10506	T
 A12	nuc	13251	G
-			
+
 A13	nuc	89	G
 A13	N	84	K
-			
+
 A14	nuc	1349	T
 A14	nuc	3994	A
 A14	nuc	5619	T
-			
+
 A15	nuc	46	A
 A15	nuc	4226	G
-			
+
 A16	nuc	6064	C
 A16	nuc	9379	T
-			
-			
+
+
 A17	L	216	S
 A17	F	574	S
-			
+
 A18	G	297	K
 A18	L	217	P
-			
+
 A19	clade	A18	
 A19	G	133	I
-			
+
 A20	nuc	8976	C
-			
+
 A21	nuc	461	C
-			
+
 A22	nuc	47	C
 A22	nuc	1910	G
 A22	nuc	4467	C
-			
+
 A23	clade	A20	
 A23	nuc	1223	T
 A23	nuc	2066	G

--- a/config/clades_genome_b.tsv
+++ b/config/clades_genome_b.tsv
@@ -1,19 +1,19 @@
 clade	gene	site	alt
 B1	L	232	T
 B1	G	261	T
-			
+
 B2	G	154	I
 B2	G	77	S
-			
+
 B3	G	152	L
 B3	nuc	381	C
-			
+
 B5	G	255	A
 B5	G	258	G
-			
+
 B4	nuc	1235	A
 B4	G	116	T
-			
+
 B6	nuc	1082	G
 B6	nuc	3325	C
 B6	nuc	3634	A


### PR DESCRIPTION
### Description of proposed changes

Discovered as part of https://github.com/nextstrain/augur/pull/1293 that the clade TSVs for this repo has excess whitespace which causes it to bypass the default `skip_blank_lines=True` behavior for `pandas.read_csv`.

The issue has been fixed in Augur, but still nice to remove the excess whitespace here to keep things uniform with other pathogen clade TSVs.

Note that the trailing whitespace after inherited clade definitions are required.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
