### PR TITLE
ingest: Remove parameters related to trigger

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -45,18 +45,8 @@ jobs:
           echo "s3_dst=$S3_DST" >> "$GITHUB_OUTPUT"
         env:
           TRIAL_NAME: ${{ inputs.trial_name }}
-      - id: trigger_rebuild
-        run: |
-          TRIGGER_REBUILD=true
-
-          if [[ -n "$TRIAL_NAME" ]]; then
-            TRIGGER_REBUILD=false
-          fi
-
-          echo "trigger_rebuild=$TRIGGER_REBUILD" >> "$GITHUB_OUTPUT"
     outputs:
       s3_dst: ${{ steps.s3_dst.outputs.s3_dst }}
-      trigger_rebuild: ${{ steps.trigger_rebuild.outputs.trigger_rebuild }}
 
   fetch-and-ingest:
     needs: [set_config_overrides]
@@ -77,11 +67,9 @@ jobs:
           --env AWS_SECRET_ACCESS_KEY \
           --env PAT_GITHUB_DISPATCH="$GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH" \
           --env S3_DST \
-          --env TRIGGER_REBUILD \
           ingest \
             --configfiles config/config.yaml config/optional.yaml \
-            --config s3_dst="$S3_DST" trigger_rebuild="$TRIGGER_REBUILD" \
+            --config s3_dst="$S3_DST" \
             --printshellcmds
       env: |
         S3_DST: ${{ needs.set_config_overrides.outputs.s3_dst }}
-        TRIGGER_REBUILD: ${{ needs.set_config_overrides.outputs.trigger_rebuild }}

--- a/ingest/config/optional.yaml
+++ b/ingest/config/optional.yaml
@@ -24,6 +24,3 @@ upload:
       'b/sequences.fasta.xz'
     ]
     cloudfront_domain: 'data.nextstrain.org'
-
-# Toggle for triggering builds
-trigger_rebuild: True


### PR DESCRIPTION
Realized through https://github.com/nextstrain/rsv/pull/37 that the ingest pipeline does _not_ trigger the rebuild. The rebuild is just scheduled to run after the ingest workflow. Removing all parameters and references to trigger in this commit so that it does not confuse anyone else in the future.

Keeping the schedule as-is since it's been working fine and we are planning to be shift pathogen workflows in the future to be able to go from ingest to a build within a single run without going through triggers and S3 interactions.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
