### PR TITLE
ingest: Conditionally include upload rule

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -47,6 +47,7 @@ include: "workflow/snakemake_rules/fetch_sequences.smk"
 
 include: "workflow/snakemake_rules/transform.smk"
 
-include: "workflow/snakemake_rules/upload.smk"
+if "s3_dst" in config:
+    include: "workflow/snakemake_rules/upload.smk"
 
 include: "workflow/snakemake_rules/sort.smk"


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This change allows the workflow to run when `s3_dst` is not defined, since the upload rule requires it to be defined.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Ingest workflow runs locally without `s3_dst` defined

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
