### PR TITLE
Replace deprecated seq.ungap()

### DIFF
--- a/scripts/cut.py
+++ b/scripts/cut.py
@@ -21,7 +21,7 @@ def cut(oldalignment, newalignment, referencefile, gene, min_length=0):
         alignment =SeqIO.parse(oldalignment, 'fasta')
         for entry in alignment:
             newrecord = SeqRecord(Seq(entry.seq[startofgene:endofgene]), id=entry.id, description=entry.description)
-            if len(newrecord.seq.ungap('-')) >= min_length:
+            if len(newrecord.seq.replace('-', '')) >= min_length:
                 list1.append(newrecord)
 
         for record in list1:


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This was deprecated in Biopython 1.79 and removed in 1.82.¹

¹ <https://github.com/biopython/biopython/blob/15dcc258a2941910fcedcb641777d2c15244d1cb/DEPRECATED.rst#bioseqsequngap>

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Discovered in https://github.com/nextstrain/docker-base/pull/200#issuecomment-1868101386

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
