### PR TITLE
Allows for CDS (as well as gene) features to generate a new gene reference

### DIFF
--- a/scripts/newreference.py
+++ b/scripts/newreference.py
@@ -3,6 +3,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature, FeatureLocation, Seq
 import shutil
 import argparse
+import sys
 
 def new_reference(referencefile, outgenbank, outfasta, gene):
     ref = SeqIO.read(referencefile, "genbank")
@@ -16,6 +17,12 @@ def new_reference(referencefile, outgenbank, outfasta, gene):
             if a == gene:
                 startofgene = int(list(feature.location)[0])
                 endofgene =  int(list(feature.location)[-1])+1
+
+    # If user provides a --gene 'some name' is not found, print a warning and use the entire genome.
+    # Otherwise do not print a warning.
+    if(gene is not None and startofgene is None and endofgene is None):
+        print(f"ERROR: No '{gene}' was found under 'gene' or 'CDS' features in the GenBank file.", file=sys.stderr)
+        sys.exit(1)
 
     record = ref[startofgene:endofgene]
     source_feature =  SeqFeature(FeatureLocation(start=0, end=len(record)), type='source',

--- a/scripts/newreference.py
+++ b/scripts/newreference.py
@@ -6,10 +6,12 @@ import argparse
 
 def new_reference(referencefile, outgenbank, outfasta, gene):
     ref = SeqIO.read(referencefile, "genbank")
+    startofgene = None
+    endofgene = None
     for feature in ref.features:
         if feature.type == 'source':
             ref_source_feature = feature
-        if feature.type =='gene':
+        if feature.type =='gene' or feature.type == 'CDS':
             a = list(feature.qualifiers.items())[0][-1][0]
             if a == gene:
                 startofgene = int(list(feature.location)[0])


### PR DESCRIPTION
## Description of proposed changes

It seems that we intend to use the `newreference.py` script as a template for creating gene trees for other viruses (e.g. dengue, measles). The `newreference.py` script processes a GenBank file, producing new gene reference files (GenBank and FASTA) which are required for creating the Nextstrain gene tree views. 

When using the `scripts/newreference.py` to generate an E gene reference for Dengue: 

```bash
curl "https://raw.githubusercontent.com/nextstrain/dengue/main/phylogenetic/config/reference_dengue_all.gb" > dengue_reference.gb
python scripts/newreference.py \
  --reference dengue_reference.gb \
  --output-fasta d.fa \
  --output-genbank d.gb \
  --gene E
```

Encountered error

```bash
Traceback (most recent call last):
  File "/Users/jchang3/github/nextstrain/rsv_branches/main/scripts/newreference.py", line 43, in <module>
    new_reference(args.reference, args.output_genbank, args.output_fasta, args.gene)
  File "/Users/jchang3/github/nextstrain/rsv_branches/main/scripts/newreference.py", line 18, in new_reference
    record = ref[startofgene:endofgene]
UnboundLocalError: local variable 'startofgene' referenced before assignment
```

The underlying issue was that the script is looking for a "gene" feature" and was ignoring "CDS" features and this PR extends the functionality to CDS. 

Looking at the [measles genbank reference](https://github.com/nextstrain/measles/blob/9377ef6623cf3b5ea779ef3a3244f98b76ddc426/phylogenetic/defaults/measles_reference.gb#L71-L86), it will also require the CDS functionality to pull out the N gene.

## Related issue(s)

## Checklist

- [ ] Checks pass

