### PR TITLE
docs: fix documentation for newreference.py to reflect --gene behavior

### DIFF
--- a/scripts/newreference.py
+++ b/scripts/newreference.py
@@ -18,8 +18,8 @@ def new_reference(referencefile, outgenbank, outfasta, gene):
                 startofgene = int(list(feature.location)[0])
                 endofgene =  int(list(feature.location)[-1])+1
 
-    # If user provides a --gene 'some name' is not found, print a warning and use the entire genome.
-    # Otherwise do not print a warning.
+    # If user provides a --gene 'some name' that is not found, error out as this may indicate that
+    # the gene name is misspelled or the user may be using the wrong GenBank file.
     if(gene is not None and startofgene is None and endofgene is None):
         print(f"ERROR: No '{gene}' was found under 'gene' or 'CDS' features in the GenBank file.", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Description of proposed changes

This is a fixup to an earlier commit:

https://github.com/nextstrain/rsv/commit/8cd6a1384301161117252f8e6f612f7332bd9416

This updates the docs to reflect that the script will NOT just throw a warning, but actually error out if the gene is not found in the GenBank file. This was flagged by comment:

https://github.com/nextstrain/dengue/pull/47#discussion_r1594509088

## Related issue(s)

* https://github.com/nextstrain/dengue/pull/47

## Checklist

- [x] Checks pass
- This does not cause any behavioral change in the script, since this is editing the comments.
