### PR TITLE
ci.yaml: Pin `pathogen-repo-ci`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   pathogen-ci:
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0


### PR DESCRIPTION
## Description of proposed changes

Pin the `pathogen-repo-ci` to v0, which is before changes for the "smart" workflow were added.

## Related issue(s)

https://github.com/nextstrain/.github/issues/93

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
