### PR TITLE
ingest: Include `seqName` in Nextclade output

### DIFF
--- a/ingest/workflow/snakemake_rules/sort.smk
+++ b/ingest/workflow/snakemake_rules/sort.smk
@@ -60,7 +60,7 @@ rule nextclade:
         nextclade = "data/{type}/nextclade.tsv"
     params:
         dataset = "rsv-{type}_nextclade",
-        output_columns = "clade qc.overallScore qc.overallStatus alignmentScore  alignmentStart  alignmentEnd  coverage dynamic"
+        output_columns = "seqName clade qc.overallScore qc.overallStatus alignmentScore  alignmentStart  alignmentEnd  coverage dynamic"
     threads: 8
     shell:
         """
@@ -84,4 +84,3 @@ rule extend_metadata:
                                        --nextclade {input.nextclade} \
                                        --output {output.metadata}
         """
-


### PR DESCRIPTION
Resolves https://github.com/nextstrain/rsv/issues/65

Since Nextclade v3.7.0, the `seqName` column needs to be explicitly listed when using the `--output-columns-selection` option.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run of ingest](https://github.com/nextstrain/rsv/actions/runs/9491549829)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
