### PR TITLE
Remove unused color_schemes config

### DIFF
--- a/config/configfile.yaml
+++ b/config/configfile.yaml
@@ -42,7 +42,6 @@ filter:
     F: 3000
 
 files:
-  color_schemes: "config/colors.tsv"
   auspice_config: "config/auspice_config.json"
 
 refine:


### PR DESCRIPTION
## Description of proposed changes

The config value has never been used, and the referenced file was removed in "add color orderings, remove stray colorings, add titles to glyc" (5f1f99f7).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
