### PR TITLE
ingest: Fix PPX division

### DIFF
--- a/ingest/bin/parse-ppx-division
+++ b/ingest/bin/parse-ppx-division
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Parse Pathoplexus division field into two separate fields, "division" and "location".
+"""
+import sys
+import argparse
+from typing import Iterable
+
+from augur.curate import validate_records
+from augur.io.json import dump_ndjson, load_ndjson
+
+
+def run(args: argparse.Namespace, records: Iterable[dict]) -> Iterable[dict]:
+
+    for index, record in enumerate(records):
+        record = record.copy()
+
+        original_division = record.get(args.division_field, None)
+        original_location = record.get(args.location_field, "").strip()
+
+        if original_division is None:
+            raise Exception(f"Records must have divison field {args.division_field!r}")
+
+        # Modified from how `augur curate parse-genbank-location` treats the division field
+        # <https://github.com/nextstrain/augur/blob/5d99406b76bfd28444eddbd47a6565086d2f94be/augur/curate/parse_genbank_location.py#L37-L38>
+        division, _, location = original_division.partition(",")
+
+        record[args.division_field] = division.strip()
+        if not original_location:
+            record[args.location_field] = location.strip()
+
+        yield record
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--division-field", default="division",
+        help="The field in the record that contains the Pathoplexus division. " \
+             "Expected to have a comma to separate division and location, " \
+             "<division>[, <location>]")
+    parser.add_argument("--location-field", default="location",
+        help="The field in the record for detailed location, e.g. county. " \
+             "This field will get filled with the detailed location parsed " \
+             "from the division field if it does not already have a non-empy string.")
+
+    args = parser.parse_args()
+
+    records = load_ndjson(sys.stdin)
+
+    # Validate records have the same input fields
+    validated_input_records = validate_records(records, __doc__, True)
+
+    # Run this custom curate command to get modified records
+    modified_records = run(args, validated_input_records)
+
+    # Validate modified records have the same output fields
+    validated_output_records = validate_records(modified_records, __doc__, False)
+
+    dump_ndjson(validated_output_records)

--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -63,6 +63,8 @@ curate:
   authors_default_value: '?'
   # Field name for the generated abbreviated authors
   abbr_authors_field: 'abbr_authors'
+  ppx_division_field: 'division'
+  location_field: 'location'
   # Local geolocation rules that are only applicable to rsv data
   local_geolocation_rules: 'source-data/geolocation-rules.tsv'
   # User annotations file

--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -46,8 +46,6 @@ curate:
   # These date formats should use directives expected by datetime
   # See https://docs.python.org/3.9/library/datetime.html#strftime-and-strptime-format-codes
   expected_date_formats: ['%Y', '%Y-%m', '%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
-  # The expected field that contains the GenBank geo_loc_name
-  genbank_location_field: location
   # Titlecase rules
   titlecase:
     # Abbreviations not cast to titlecase, keeps uppercase

--- a/ingest/source-data/geolocation-rules.tsv
+++ b/ingest/source-data/geolocation-rules.tsv
@@ -14,3 +14,17 @@ Europe/Italy/Fvg/Gorizia	Europe/Italy/Friuli Venezia Giulia/Gorizia
 # Unclear which location is the real location
 Europe/Netherlands/Utrecht/Rotterdam	Europe/Netherlands//
 North America/USA/Washington/Dc	North America/USA/Washington DC/
+
+# General rules that should be transferred to Augur
+*/Cambodia/*/*	Asia/Cambodia/*/*
+*/Central African Republic/*/*	Africa/Central African Republic/*/*
+*/Cote d'Ivoire/*/*	Africa/Côte d'Ivoire/*/*
+*/Cuba/*/*	North America/Cuba/*/*
+*/Gambia/*/*	Africa/Gambia/*/*
+*/Jordan/*/*	Asia/Jordan/*/*
+*/Korea/*/*	Asia/South Korea/*/*
+*/Mali/*/*	Africa/Mali/*/*
+*/Mongolia/*/*	Asia/Mongolia/*/*
+*/Nicaragua/*/*	North America/Nicaragua/*/*
+*/Singapore/*/*	Asia/Singapore/*/*
+*/Viet Nam/*/*	Asia/Vietnam/*/*

--- a/ingest/workflow/snakemake_rules/curate.smk
+++ b/ingest/workflow/snakemake_rules/curate.smk
@@ -42,6 +42,8 @@ rule curate:
         authors_field = config['curate']['authors_field'],
         authors_default_value = config['curate']['authors_default_value'],
         abbr_authors_field = config['curate']['abbr_authors_field'],
+        ppx_division_field = config['curate']['ppx_division_field'],
+        location_field = config['curate']['location_field'],
         annotations_id = config['curate']['annotations_id'],
         id_field = config['curate']['id_field'],
         sequence_field = config['curate']['sequence_field']
@@ -65,6 +67,9 @@ rule curate:
                 --authors-field {params.authors_field} \
                 --default-value {params.authors_default_value} \
                 --abbr-authors-field {params.abbr_authors_field} \
+            | ./bin/parse-ppx-division \
+                --division-field {params.ppx_division_field:q} \
+                --location-field {params.location_field:q} \
             | augur curate apply-geolocation-rules \
                 --geolocation-rules {input.geolocation_rules} \
             | python ./bin/curate-urls.py \

--- a/ingest/workflow/snakemake_rules/curate.smk
+++ b/ingest/workflow/snakemake_rules/curate.smk
@@ -36,7 +36,6 @@ rule curate:
         strain_backup_fields = config['curate']['strain_backup_fields'],
         date_fields = config['curate']['date_fields'],
         expected_date_formats = config['curate']['expected_date_formats'],
-        genbank_location_field=config["curate"]["genbank_location_field"],
         articles = config['curate']['titlecase']['articles'],
         abbreviations = config['curate']['titlecase']['abbreviations'],
         titlecase_fields = config['curate']['titlecase']['fields'],


### PR DESCRIPTION
## Description of proposed changes

Splits PPX division into "division" and "location" fields by splitting on the comma. 
Modified from how `augur curate parse-genbank-location` [handles the division field](https://github.com/nextstrain/augur/blob/5d99406b76bfd28444eddbd47a6565086d2f94be/augur/curate/parse_genbank_location.py#L37-L38). 

## Related issue(s)

Resolves https://github.com/nextstrain/rsv/issues/99

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
