### PR TITLE
CI: Run only a/genome/all-time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,3 +10,5 @@ on:
 jobs:
   pathogen-ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0
+    with:
+      build-args: --configfile config/ci.yaml

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -1,0 +1,8 @@
+# This configuration file contains the custom configurations parameters
+# for the CI workflow to run with the example data.
+
+builds_to_run: ["genome"]
+
+resolutions_to_run: ["all-time"]
+
+subtypes: ["a"]


### PR DESCRIPTION
## Description of proposed changes

This should be sufficient for CI, instead of producing all 18 datasets.

## Related issue(s)

Closes #104 

## Checklist

- [x] Checks pass
- [x] [CI workflow run has 24 jobs](https://github.com/nextstrain/rsv/actions/runs/18107789787/job/51526580084?pr=107#step:8:39) instead of 365 jobs
- [x] ~Update changelog~ no functional change for users
- [x] Post-merge: Update calls to this CI workflow in docker-base, conda-base, augur
