### PR TITLE
Remove unused config

### DIFF
--- a/config/configfile.yaml
+++ b/config/configfile.yaml
@@ -51,9 +51,6 @@ filter:
     3y:
       min_date: 3Y
       background_min_date: 12Y
-    1y:
-      min_date: 1Y
-      background_min_date: 12Y
 
   subsample_max_sequences:
     genome: 3000


### PR DESCRIPTION
#110 added a "1y" entry to resolutions under filter config, but not resolutions_to_run. I assume this was added by mistake.

## Checklist

- [x] Checks pass
- [x] ~Update changelog~ no functional changes
