### PR TITLE
make div-units configurable

### DIFF
--- a/config/configfile.yaml
+++ b/config/configfile.yaml
@@ -74,6 +74,7 @@ refine:
   coalescent: "opt"
   date_inference: "marginal"
   clock_filter_iqd: 4
+  divergence_units: "mutations-per-site"
 
 ancestral:
   inference: "joint"

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -554,6 +554,7 @@ rule refine:
         clock_filter_iqd=config["refine"]["clock_filter_iqd"],
         date_inference=config["refine"]["date_inference"],
         strain_id=config["strain_id_field"],
+        divergence_units=config["refine"]["divergence_units"],
     shell:
         r"""
         exec &> >(tee {log:q})
@@ -570,7 +571,8 @@ rule refine:
             --timetree \
             --stochastic-resolve \
             --use-fft \
-            --clock-filter-iqd {params.clock_filter_iqd}
+            --clock-filter-iqd {params.clock_filter_iqd} \
+            --divergence-units {params.divergence_units}
         """
 
 


### PR DESCRIPTION
adds divergence-units to refine rule. Build is unchanged because set to the default of "mutations-per-site" in config.

## Description of proposed changes

adds divergence-units to refine rule. Build is unchanged because set to the default of "mutations-per-site" in config.


## Related issue(s)

- There is also a refine rune in the primary Snakefile. I did not edit this and am not positive how it interacts with the refine rule in core.smk

## Checklist


- [ ] Checks pass
- [ ] Update changelog - did not add becuase RSV build doesn't have a change log and this is not a breaking change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
