### PR TITLE
nextstrain-automation: Include rules via `custom_rules`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -47,11 +47,6 @@ include: "workflow/snakemake_rules/glycosylation.smk"
 include: "workflow/snakemake_rules/clades.smk"
 
 
-if "deploy_url" in config:
-
-    include: "workflow/snakemake_rules/nextstrain_automation.smk"
-
-
 rule clean:
     params:
         targets=["auspice", "results"],

--- a/config/nextstrain_automation.yaml
+++ b/config/nextstrain_automation.yaml
@@ -1,5 +1,8 @@
 # Optional configs to include for automated Nextstrain builds
 # Intended to be used internally by the Nextstrain team
+custom_rules:
+  - "workflow/snakemake_rules/nextstrain_automation.smk"
+
 
 # deploy
 deploy_url: "s3://nextstrain-data"


### PR DESCRIPTION
## Description of proposed changes

Using `custom_rules` allows the nextstrain-automation build to skip the config validation, which fails because of the extra `deploy_url` param.

## Related issue(s)

Follow up to https://github.com/nextstrain/rsv/pull/139

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~ Internal changes

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
